### PR TITLE
Internationalization Setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'rspec-rails'
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'launchy'
   gem 'poltergeist'
   gem 'jasmine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
     builder (3.1.4)
@@ -61,6 +63,7 @@ GEM
       nokogiri (>= 1.5.0)
       rails (>= 3.0.0)
     database_cleaner (1.2.0)
+    debug_inspector (0.0.2)
     debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -185,6 +188,7 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors
+  binding_of_caller
   bootstrap-sass
   capybara
   coffee-rails (~> 4.0.0)

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,7 +1,7 @@
 @import "shared";
 
 .translation_missing {
-  color: red;
-  text-transform: uppercase;
-  text-decoration: line-through;
+  color: red !important;
+  text-transform: uppercase !important;
+  text-decoration: line-through !important;
 }

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,0 +1,7 @@
+@import "shared";
+
+.translation_missing {
+  color: red;
+  text-transform: uppercase;
+  text-decoration: line-through;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_locale
 
-  def default_url_options(options={})
+  def default_url_options(options = {})
     { locale: I18n.locale }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_locale
 
-  def default_url_options(options = {})
-    { locale: I18n.locale }
+  unless Rails.env.test?
+    def default_url_options(options = {})
+      { locale: I18n.locale }
+    end
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,15 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :set_locale
+
+  def default_url_options(options={})
+    { locale: I18n.locale }
+  end
+
+  private
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_locale
 
-  unless Rails.env.test?
+  # TODO switch to this conditional when the site is
+  # translated properly
+  # unless Rails.env.test?
+  if Rails.env.development?
     def default_url_options(options = {})
       { locale: I18n.locale }
     end
@@ -13,6 +16,10 @@ class ApplicationController < ActionController::Base
   private
 
   def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    # TODO remove the conditional when the site is
+    # translated properly
+    unless Rails.env.production?
+      I18n.locale = params[:locale] || I18n.default_locale
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,16 @@ module ApplicationHelper
     self.output_buffer = ActionView::OutputBuffer.new(output)
   end
 
+  def language_switch_link
+    locale = (params[:locale] == 'se' ? :en : :se)
+    text_for_locale = {
+      en: t('layouts.navbar.links.switch_to_EN'),
+      se: t('layouts.navbar.links.switch_to_SE'),    }
+    raw <<-HTML
+      <li>#{link_to(text_for_locale[locale], root_url(locale: locale))}</li>
+    HTML
+  end
+
   def shared_meta_keywords
     'Codealia, Coding for Girls, Women in Technology, Coding for Kids'
   end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="collapse navbar-collapse">
     <ul class="nav navbar-nav pull-right">
-      <%= language_switch_link %>
+      <%= language_switch_link unless Rails.env.production? %>
       <li class="active"><a href="#"><%= t('layouts.navbar.links.concept_draft') %></a></li>
     </ul>
   </div><!--/.nav-collapse -->

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -9,7 +9,8 @@
   </div>
   <div class="collapse navbar-collapse">
     <ul class="nav navbar-nav pull-right">
-      <li class="active"><a href="#">Concept draft</a></li>
+      <%= language_switch_link %>
+      <li class="active"><a href="#"><%= t('layouts.navbar.links.concept_draft') %></a></li>
     </ul>
   </div><!--/.nav-collapse -->
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= t('title') %></title>
+  <title><%= t('app.title') %></title>
   <%= render 'layouts/meta_tags' %>
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -11,20 +11,22 @@
     </div>
   <% end %>
 
+  <% i18n_path = 'activerecord.attributes.post' %>
+
   <div class="field">
-    <%= f.label :title %><br>
+    <%= f.label :title, t("#{i18n_path}.title") %><br>
     <%= f.text_field :title %>
   </div>
   <div class="field">
-    <%= f.label :author %><br>
+    <%= f.label :author, t("#{i18n_path}.author") %><br>
     <%= f.text_field :author %>
   </div>
   <div class="field">
-    <%= f.label :created_at %><br>
+    <%= f.label :created_at, t("#{i18n_path}.created_at") %><br>
     <%= f.datetime_select :created_at %>
   </div>
   <div class="field">
-    <%= f.label :content %><br>
+    <%= f.label :content, t("#{i18n_path}.content") %><br>
     <%= f.text_area :content %>
   </div>
   <div class="actions">

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -5,7 +5,7 @@
 </header>
 
 <div class="well">
-  <%= t("#{i18n_path}.text.learning_code") %>
+  <%= t("#{i18n_path}.text.learning_code_html") %>
 
   <h3>The Problem</h3>
 

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,14 +1,11 @@
+<% i18n_path = 'static_pages.index' %>
 <header>
   <h2>i am</h2>
   <h1 style="margin-left: -10px !important;">codealia</h1>
 </header>
 
 <div class="well">
-  <h2>Learning Code - Building Futures</h2>
-  <h3>An Open Source Solution For Technology Education</h3>
-  <p>Codealia believes in diversity and we aspire to a future filled with smart, educated programmers - women as well as men. We are a dedicated group of software engineers who want to reverse the declining numbers of women in Computer Science.</p>
-
-  <p>Codealia seeks to level the playing field by developing a free open-source learning platform with an engaging curriculum targeting young girls.  Our interactive program will foster collaboration, teamwork and open communication which will pave the way to future careers in the information technology field.</p>
+  <%= t("#{i18n_path}.text.learning_code") %>
 
   <h3>The Problem</h3>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module Codealia
     # The default locale is :en and all translations from
     # config/locales/*.rb,yml and its sub-directories are auto loaded.
     config.i18n.default_locale = :en
+    config.i18n.enforce_available_locales = true
+    I18n.config.enforce_available_locales = true
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales',
                                                  '**', '*.{rb,yml}').to_s]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,9 +20,9 @@ module Codealia
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    # The default locale is :en and all translations from config/locales/*.rb,yml and its sub-directories are auto loaded.
+    config.i18n.default_locale = :en
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
     config.autoload_paths += Dir[File.join(Rails.root, "lib", "core_ext", "*.rb")].each {|l| require l }
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module Codealia
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.autoload_paths += Dir[File.join(Rails.root, "lib", "core_ext", "*.rb")].each {|l| require l }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,8 +23,8 @@ module Codealia
     # The default locale is :en and all translations from
     # config/locales/*.rb,yml and its sub-directories are auto loaded.
     config.i18n.default_locale = :en
-    config.i18n.enforce_available_locales = true
-    I18n.config.enforce_available_locales = true
+    config.i18n.enforce_available_locales = false
+    I18n.config.enforce_available_locales = false
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales',
                                                  '**', '*.{rb,yml}').to_s]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,9 +20,11 @@ module Codealia
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml and its sub-directories are auto loaded.
+    # The default locale is :en and all translations from
+    # config/locales/*.rb,yml and its sub-directories are auto loaded.
     config.i18n.default_locale = :en
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales',
+                                                 '**', '*.{rb,yml}').to_s]
 
     config.autoload_paths += Dir[File.join(Rails.root, "lib", "core_ext", "*.rb")].each {|l| require l }
   end

--- a/config/locales/core/en.yml
+++ b/config/locales/core/en.yml
@@ -1,0 +1,6 @@
+en:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/core/se.yml
+++ b/config/locales/core/se.yml
@@ -1,0 +1,6 @@
+se:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/new/pending.en.yml
+++ b/config/locales/new/pending.en.yml
@@ -1,0 +1,23 @@
+en:
+  layouts:
+    navbar:
+      links:
+        concept_draft: "Concept draft"
+  static_pages:
+    index:
+      text:
+        learning_code:
+          "
+          <h2>Learning Code - Building Futures</h2>
+          <h3>An Open Source Solution For Technology Education</h3>
+          <p>Codealia believes in diversity and we aspire to a future filled
+          with smart, educated programmers - women as well as men. We are a
+          dedicated group of software engineers who want to reverse the
+          declining numbers of women in Computer Science</p>
+
+          <p>Codealia seeks to level the playing field by developing a
+          free open-source learning platform with an engaging curriculum
+          targeting young girls. Our interactive program will foster
+          collaboration, teamwork and open communication which will pave
+          the way to future careers in the information technology field.</p>
+          "

--- a/config/locales/new/pending.en.yml
+++ b/config/locales/new/pending.en.yml
@@ -3,6 +3,8 @@ en:
     navbar:
       links:
         concept_draft: "Concept draft"
+        switch_to_EN: "EN"
+        switch_to_SE: "SE"
   static_pages:
     index:
       text:
@@ -21,3 +23,17 @@ en:
           collaboration, teamwork and open communication which will pave
           the way to future careers in the information technology field.</p>
           "
+  activerecord:
+    models:
+      post:
+        one: "Post"
+        other: "Posts"
+    errors:
+      messages:
+        blank: "%{attribute} cannot be blank"
+    attributes:
+      post:
+        title: "Title"
+        author: "Author"
+        content: "Content"
+        created_at: "Created at"

--- a/config/locales/new/pending.en.yml
+++ b/config/locales/new/pending.en.yml
@@ -8,7 +8,7 @@ en:
   static_pages:
     index:
       text:
-        learning_code:
+        learning_code_html:
           "
           <h2>Learning Code - Building Futures</h2>
           <h3>An Open Source Solution For Technology Education</h3>

--- a/config/locales/se.yml
+++ b/config/locales/se.yml
@@ -1,2 +1,0 @@
-se:
-  title: "Codealia"

--- a/config/locales/se.yml
+++ b/config/locales/se.yml
@@ -1,3 +1,2 @@
-
 se:
   title: "Codealia"

--- a/config/locales/translated/en.yml
+++ b/config/locales/translated/en.yml
@@ -20,4 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  title: "Codealia"
+  app:
+    title: "Codealia"
+  layouts:
+    navbar:
+      links:
+        switch_to_EN: "EN"
+        switch_to_SE: "SE"

--- a/config/locales/translated/en.yml
+++ b/config/locales/translated/en.yml
@@ -22,8 +22,3 @@
 en:
   app:
     title: "Codealia"
-  layouts:
-    navbar:
-      links:
-        switch_to_EN: "EN"
-        switch_to_SE: "SE"

--- a/config/locales/translated/se.yml
+++ b/config/locales/translated/se.yml
@@ -1,0 +1,8 @@
+se:
+  app:
+    title: "Codealia"
+  layouts:
+    navbar:
+      links:
+        switch_to_EN: "EN"
+        switch_to_SE: "SE"

--- a/config/locales/translated/se.yml
+++ b/config/locales/translated/se.yml
@@ -1,8 +1,3 @@
 se:
   app:
     title: "Codealia"
-  layouts:
-    navbar:
-      links:
-        switch_to_EN: "EN"
-        switch_to_SE: "SE"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -54,7 +54,7 @@ end
 
 Then(/^I should see[ a]* link to the "(.*?)" page$/) do |page_name|
   url = path_to(page_name)
-  page.should have_xpath "//a[@href='#{url}']"
+  page.should have_css "a[href^=\"#{url}\"]"
 end
 
 Given(/^I should see[ a]* link "([^"]*)" to "([^"]*)"$/) do |link_text, link|

--- a/lib/core_ext/translation_helper_extension.rb
+++ b/lib/core_ext/translation_helper_extension.rb
@@ -1,7 +1,7 @@
 module ActionView
   module Helpers
     module TranslationHelper
-      if Rails.env.development?
+      unless Rails.env.production?
         alias :old_translate :translate
         def translate(key, options = {})
           # display what has been translated

--- a/lib/core_ext/translation_helper_extension.rb
+++ b/lib/core_ext/translation_helper_extension.rb
@@ -5,7 +5,7 @@ module ActionView
         alias :old_translate :translate
         def translate(key, options = {})
           # display what has been translated
-          "{{ #{old_translate(key, options)} }}"
+          raw "{{ #{old_translate(key, options)} }}"
         end
         alias :t :translate
       end

--- a/lib/core_ext/translation_helper_extension.rb
+++ b/lib/core_ext/translation_helper_extension.rb
@@ -1,0 +1,14 @@
+module ActionView
+  module Helpers
+    module TranslationHelper
+      if Rails.env.development?
+        alias :old_translate :translate
+        def translate(key, options = {})
+          # display what has been translated
+          "{{ #{old_translate(key, options)} }}"
+        end
+        alias :t :translate
+      end
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -12,7 +12,7 @@ describe Comment do
     [:post, :name, :body].each do |attribute|
       it "should validate presence of #{attribute}" do
         expect(comment).to have_at_least(1).error_on(attribute)
-        expect(comment.errors.messages[attribute]).to include "can't be blank"
+        expect(comment.errors.messages[attribute]).to include I18n.t("activerecord.errors.messages.blank", attribute: attribute.capitalize)
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,14 +5,15 @@ require 'spec_helper'
 
 describe Comment do
   describe 'validation' do
-    subject(:comment) {Comment.new}
-    before {comment.valid? }
+    subject(:comment) { Comment.new }
+    before { comment.valid? }
 
 
     [:post, :name, :body].each do |attribute|
       it "should validate presence of #{attribute}" do
         expect(comment).to have_at_least(1).error_on(attribute)
-        expect(comment.errors.messages[attribute]).to include I18n.t("activerecord.errors.messages.blank", attribute: attribute.capitalize)
+        expect(comment.errors.messages[attribute]).to include I18n.t(
+          'activerecord.errors.messages.blank', attribute: attribute.capitalize)
       end
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,20 +1,15 @@
 require 'spec_helper'
 
+describe Post do
+  describe 'validations' do
+    subject(:post) {Post.new}
+    before { post.valid? }
 
-
-#RSpec Unit test on Post model
-
-        describe Post do
-          describe 'validations' do
-                subject(:post) {Post.new}
-                before { post.valid? }
-
-
-            [:title, :author, :content].each do |attribute|
-              it "should validate presence of #{attribute}" do
-              expect(post).to have_at_least(1).error_on(attribute)
-              expect(post.errors.messages[attribute]).to include "can't be blank"
-              end
-            end
-          end
-        end
+    [:title, :author, :content].each do |attribute|
+      it "should validate presence of #{attribute}" do
+        expect(post).to have_at_least(1).error_on(attribute)
+        expect(post.errors.messages[attribute]).to include I18n.t("activerecord.errors.messages.blank", attribute: attribute.capitalize)
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Post do
   describe 'validations' do
-    subject(:post) {Post.new}
+    subject(:post) { Post.new }
     before { post.valid? }
 
     [:title, :author, :content].each do |attribute|
       it "should validate presence of #{attribute}" do
         expect(post).to have_at_least(1).error_on(attribute)
-        expect(post.errors.messages[attribute]).to include I18n.t("activerecord.errors.messages.blank", attribute: attribute.capitalize)
+        expect(post.errors.messages[attribute]).to include I18n.t(
+          'activerecord.errors.messages.blank', attribute: attribute.capitalize)
       end
     end
   end


### PR DESCRIPTION
[Pivotal Tracker](https://www.pivotaltracker.com/story/show/67496894)
- Extended `ActionView::Helpers::TranslationHelper` to include indicators for translated text in all environments except `production`
- Add locale to URL parameters
- Add a locale switch in the header
- Basic translation skeletons added to `config/locales/` with a simple file structure
- Add `binding_of_caller` gem for use with `better_errors` (should have been added the first time)

**Note** ActiveRecord does not recognise default translations for some reason, despite following the documentation. A bug has been set up -> [here](https://www.pivotaltracker.com/story/show/70226658)
