### PR TITLE
CC and MIT license inclusion

### DIFF
--- a/app/views/static_pages/terms_and_conditions.html.erb
+++ b/app/views/static_pages/terms_and_conditions.html.erb
@@ -1,6 +1,6 @@
 <h2>Codealia Terms and Conditions ("Agreement")</h2>
 <div class="well">
-  <p>This Agreement was last modified on the 8<sup>th</sup> of May 2014.</p>
+  <p>This Agreement was last modified on the 8<sup>th</sup> of June 2014.</p>
 
   <p>Please read these Terms and Conditions ("Agreement", "Terms and Conditions") carefully before using http://codealia.org ("the Site") operated by AGILEVENTURES NONPROFIT LTD. ("us", "we", or "our"). This Agreement sets forth the legally binding terms and conditions for your use of the Site at http://codealia.org.</p>
   <p>By accessing or using the Site in any manner, including, but not limited to, visiting or browsing the Site or contributing content or other materials to the Site, you agree to be bound by these Terms and Conditions. Capitalized terms are defined in this Agreement.</p>
@@ -14,20 +14,9 @@
   <p><strong>Attribution</strong><br />You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.</p>
 
   <p><strong>Intellectual Property: Source code</strong><br />
-    The Site and its features, functionality and source code are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD</a> open source license:</p>
+    The Site and its features, functionality and source code are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://opensource.org/licenses/MIT">MIT</a> open source license:</p>
   <blockquote>
-    <p>Copyright (c) 2014, AGILEVENTURES NONPROFIT LTD.<br>
-    All rights reserved.</p>
-
-    <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
-
-    <p>1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</p>
-
-    <p>2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</p>
-
-    <p>3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</p>
-
-    <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+    <%= render file: 'LICENSE' %>
   </blockquote>
 
   <p><strong>Termination</strong><br />We may terminate your access to the Site, without cause or notice, which may result in the forfeiture and destruction of all information associated with you. All provisions of this Agreement that by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>

--- a/app/views/static_pages/terms_and_conditions.html.erb
+++ b/app/views/static_pages/terms_and_conditions.html.erb
@@ -1,11 +1,40 @@
 <h2>Codealia Terms and Conditions ("Agreement")</h2>
 <div class="well">
-  <p>This Agreement was last modified on March 20, 2014.</p>
+  <p>This Agreement was last modified on the 8<sup>th</sup> of May 2014.</p>
 
   <p>Please read these Terms and Conditions ("Agreement", "Terms and Conditions") carefully before using http://codealia.org ("the Site") operated by AGILEVENTURES NONPROFIT LTD. ("us", "we", or "our"). This Agreement sets forth the legally binding terms and conditions for your use of the Site at http://codealia.org.</p>
   <p>By accessing or using the Site in any manner, including, but not limited to, visiting or browsing the Site or contributing content or other materials to the Site, you agree to be bound by these Terms and Conditions. Capitalized terms are defined in this Agreement.</p>
 
-  <p><strong>Intellectual Property</strong><br />The Site and its original content, features and functionality are owned by AGILEVENTURES NONPROFIT LTD. and are protected by international copyright, trademark, patent, trade secret and other intellectual property or proprietary rights laws.</p>
+  <p><strong>Intellectual Property: Content</strong><br />The Site and its original content are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution</a> license. You are free to:
+  <ul>
+    <li>Share — copy and redistribute the material in any medium or format</li>
+    <li>Adapt — remix, transform, and build upon the material</li>
+  </ul>
+  for any purpose, even commercially. Under the folowing terms:</p>
+  <p><strong>Attribution</strong><br />You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.</p>
+
+  <p><strong>Intellectual Property: Source code</strong><br />The Site and its features, functionality and source code are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://opensource.org/licenses/MIT">MIT</a> open source license:</p>
+  <blockquote>
+    <p>Copyright (c) 2014 AGILEVENTURES NONPROFIT LTD.
+
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:</p>
+
+    <p>The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.</p>
+
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.</p>
+  </blockquote>
 
   <p><strong>Termination</strong><br />We may terminate your access to the Site, without cause or notice, which may result in the forfeiture and destruction of all information associated with you. All provisions of this Agreement that by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>
 

--- a/app/views/static_pages/terms_and_conditions.html.erb
+++ b/app/views/static_pages/terms_and_conditions.html.erb
@@ -13,27 +13,21 @@
   for any purpose, even commercially. Under the folowing terms:</p>
   <p><strong>Attribution</strong><br />You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.</p>
 
-  <p><strong>Intellectual Property: Source code</strong><br />The Site and its features, functionality and source code are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://opensource.org/licenses/MIT">MIT</a> open source license:</p>
+  <p><strong>Intellectual Property: Source code</strong><br />
+    The Site and its features, functionality and source code are owned by AGILEVENTURES NONPROFIT LTD. and are licenced under the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD</a> open source license:</p>
   <blockquote>
-    <p>Copyright (c) 2014 AGILEVENTURES NONPROFIT LTD.
+    <p>Copyright (c) 2014, AGILEVENTURES NONPROFIT LTD.<br>
+    All rights reserved.</p>
 
-    <p>Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:</p>
+    <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
-    <p>The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.</p>
+    <p>1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</p>
 
-    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.</p>
+    <p>2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</p>
+
+    <p>3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</p>
+
+    <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
   </blockquote>
 
   <p><strong>Termination</strong><br />We may terminate your access to the Site, without cause or notice, which may result in the forfeiture and destruction of all information associated with you. All provisions of this Agreement that by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>


### PR DESCRIPTION
[Pivotal Chore 67910808](https://www.pivotaltracker.com/story/show/67910808) Terms of Service and Privacy Policy on website
- Removes restrictive boilerplate copyright notice
- Adds Creative Commons Attribution license in context of site content
- Adds MIT license in context of source code by rendering the `LICENSE` file so that this can be altered in-place in future
