### PR TITLE
add new css file for precompilation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Codealia::Application.configure do
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   config.assets.precompile += %w(
-    codealia-ide/angular-app.js codealia-ide.css
+    codealia-ide/angular-app.js codealia-ide.css workshop/passion.css
   )
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Codealia::Application.configure do
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   config.assets.precompile += %w(
-    codealia-ide/angular-app.js codealia-ide.css workshop/passion.css
+    workshop/passion.css
   )
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
Fixes the broken workshop1 preview styling on develop.

[heroku preview](http://quiet-island-6214.herokuapp.com/)
