### PR TITLE
replaced debugger with the pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ end
 
 group :development, :test do
   gem 'cucumber-rails', :require => false
-  gem 'debugger', '~> 1.6.6'
+  gem 'awesome_print' # plays well with pry
+  gem 'pry-byebug' # replaces pry (which uses the deprecated debugger gem)
   gem 'capybara'
   gem 'database_cleaner'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
+    awesome_print (1.2.0)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -37,6 +38,9 @@ GEM
     bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capybara (2.2.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -66,12 +70,7 @@ GEM
       rails (>= 3.0.0)
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
-    debugger (1.6.6)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.0.2)
@@ -100,6 +99,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.3)
     minitest (5.3.3)
@@ -115,6 +115,13 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     polyglot (0.3.4)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -162,6 +169,7 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
+    slop (3.5.0)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -192,6 +200,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   better_errors
   binding_of_caller
   bootstrap-sass
@@ -199,7 +208,6 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   cucumber-rails
   database_cleaner
-  debugger (~> 1.6.6)
   font-awesome-rails
   jasmine
   jasmine-jquery-rails
@@ -208,6 +216,7 @@ DEPENDENCIES
   launchy
   pg
   poltergeist
+  pry-byebug
   rails (= 4.1.0)
   rails_12factor
   rspec-rails


### PR DESCRIPTION
- Replaced the deprecated `debugger` gem with `pry-byebug` which uses the `byebug` gem which is compatible with Ruby >2.0.0
